### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,20 +14,13 @@
     <description>Sneak and Fart!</description>
     <properties>
         <java.version>17</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,19 +66,19 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.20.4-R0.1-SNAPSHOT</version>
+            <version>1.21.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>3.0.2</version>
+            <version>3.1.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>24.1.0</version>
+            <version>26.0.2</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,11 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- dependency and plugins version -->
+        <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
+        <spigot-api.version>1.21.5-R0.1-SNAPSHOT</spigot-api.version>
+        <bstats-bukkit.version>3.1.0</bstats-bukkit.version>
+        <annotations.version>26</annotations.version>
     </properties>
 
     <build>
@@ -24,7 +29,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>${maven-shade-plugin.version}</version>
                 <configuration>
                     <relocations>
                         <relocation>
@@ -66,19 +71,19 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.21.5-R0.1-SNAPSHOT</version>
+            <version>${spigot-api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>3.1.0</version>
+            <version>${bstats-bukkit.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>26.0.2</version>
+            <version>${annotations.version}.0.2</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/scripts/check-spigot-compatibility.sh
+++ b/scripts/check-spigot-compatibility.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+AWK_SCRIPT='
+  {
+    # key = major and minor version
+    key = $1 "." $2
+    # store in map (associative array) with overwrite
+    latest[key] = $0
+  }
+  END {
+    # print final map values
+    for (k in latest) print latest[k]
+  }
+'
+
+# Print latest spigot version per minor version
+fetch_versions() {
+  # index of spigot-api versions (maven repository)
+  curl -s https://hub.spigotmc.org/nexus/content/repositories/snapshots/org/spigotmc/spigot-api/maven-metadata.xml |
+  # keep version number only
+  sed -n 's#.*<version>\(.*\)</version>.*#\1#p' |
+  # without experimental versions
+  grep -v -- '-experimental' |
+  # sort by version
+  sort --version-sort |
+  # keep last per minor version
+  awk -F '[.-]' "$AWK_SCRIPT" |
+  # sort by version again (map output is unsorted)
+  sort -V
+}
+
+# Assign result of function to array
+VERSIONS=($(fetch_versions))
+
+# Arrays to track results
+SUCCESSFUL=()
+FAILED=()
+
+for i in "${!VERSIONS[@]}"; do
+	VERSION=${VERSIONS[$i]}
+	printf 'Running: mvn clean verify -Dspigot-api.version=%s ... ' $VERSION >&2
+	if mvn --quiet --batch-mode clean verify -Dspigot-api.version=$VERSION &> /dev/null; then
+		SUCCESSFUL+=($VERSION)
+	  printf 'success\n' >&2
+	else
+		FAILED+=($VERSION)
+	  printf 'failed\n' >&2
+	fi
+done
+
+# Summary
+echo  >&2
+echo "==================== Summary ====================" >&2
+echo  >&2
+
+echo "# Spigot Compatibility Report"
+echo
+echo "## Compatible versions"
+echo
+echo "✅ Plugin builds cleanly for the listed Spigot versions"
+echo "⚠️ This means the plugin is likely to work with these versions"
+echo "🎮️ Not every version was tested in-game"
+echo
+for VERSION in "${SUCCESSFUL[@]}"; do
+  SHORT_VERSION="$(cut -d. -f1,2 <<< "$VERSION")"
+  echo "  - $SHORT_VERSION ($VERSION)"
+done
+
+echo
+echo "*************************************************"
+echo
+echo "## Incompatible versions"
+echo
+echo "❌ Plugin will not work with these Spigot versions"
+echo
+for VERSION in "${FAILED[@]}"; do
+  SHORT_VERSION="$(cut -d. -f1,2 <<< "$VERSION")"
+  echo "  - $SHORT_VERSION ($VERSION)"
+done

--- a/src/main/java/nezd53/sneakfart/FartHandler.java
+++ b/src/main/java/nezd53/sneakfart/FartHandler.java
@@ -8,7 +8,6 @@ import org.bukkit.entity.Zombie;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
 import org.bukkit.profile.PlayerProfile;
 import org.bukkit.profile.PlayerTextures;
 import org.bukkit.util.Vector;
@@ -30,7 +29,7 @@ public class FartHandler {
         float yaw = player.getLocation().getYaw();
         Vector offset = new Vector(sin(toRadians(yaw)) * fartDistance, 0.25, -cos(toRadians(yaw)) * fartDistance);
         Location l = player.getLocation().add(offset);
-        player.getWorld().spawnParticle(Particle.DUST, l,
+      player.getWorld().spawnParticle(SpigotCompat.DUST_PARTICLE, l,
                 25, fartOffset, fartOffset, fartOffset, options);
         player.playSound(l, Sound.BLOCK_WET_GRASS_PLACE, (float) fartVolume, 0.005f);
 
@@ -87,7 +86,7 @@ public class FartHandler {
                     zombie.setInvisible(true);
                     zombie.setSilent(true);
                     zombie.setHealth(1);
-                    zombie.setLootTable(null);
+                    zombie.setLootTable(SpigotCompat.EMPTY_LOOT_TABLE);
                     zombie.setInvisible(true);
                     zombie.setCustomName("Deadly Poop");
                 });
@@ -100,6 +99,6 @@ public class FartHandler {
                 .flatMap(List::stream)
                 .filter(p -> p.getLocation().distance(l) <= nauseaDistance)
                 .filter(Predicate.not(player::equals))
-                .forEach(p -> p.addPotionEffect(new PotionEffect(PotionEffectType.NAUSEA, 5 * 20, 5)));
+                .forEach(p -> p.addPotionEffect(new PotionEffect(SpigotCompat.NAUSEA_EFFECT, 5 * 20, 5)));
     }
 }

--- a/src/main/java/nezd53/sneakfart/FartHandler.java
+++ b/src/main/java/nezd53/sneakfart/FartHandler.java
@@ -7,7 +7,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.entity.Zombie;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
-import org.bukkit.loot.LootTables;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.profile.PlayerProfile;
@@ -31,7 +30,7 @@ public class FartHandler {
         float yaw = player.getLocation().getYaw();
         Vector offset = new Vector(sin(toRadians(yaw)) * fartDistance, 0.25, -cos(toRadians(yaw)) * fartDistance);
         Location l = player.getLocation().add(offset);
-        player.getWorld().spawnParticle(Particle.REDSTONE, l,
+        player.getWorld().spawnParticle(Particle.DUST, l,
                 25, fartOffset, fartOffset, fartOffset, options);
         player.playSound(l, Sound.BLOCK_WET_GRASS_PLACE, (float) fartVolume, 0.005f);
 
@@ -88,7 +87,7 @@ public class FartHandler {
                     zombie.setInvisible(true);
                     zombie.setSilent(true);
                     zombie.setHealth(1);
-                    zombie.setLootTable(LootTables.EMPTY.getLootTable());
+                    zombie.setLootTable(null);
                     zombie.setInvisible(true);
                     zombie.setCustomName("Deadly Poop");
                 });
@@ -101,6 +100,6 @@ public class FartHandler {
                 .flatMap(List::stream)
                 .filter(p -> p.getLocation().distance(l) <= nauseaDistance)
                 .filter(Predicate.not(player::equals))
-                .forEach(p -> p.addPotionEffect(new PotionEffect(PotionEffectType.CONFUSION, 5 * 20, 5)));
+                .forEach(p -> p.addPotionEffect(new PotionEffect(PotionEffectType.NAUSEA, 5 * 20, 5)));
     }
 }

--- a/src/main/java/nezd53/sneakfart/SpigotCompat.java
+++ b/src/main/java/nezd53/sneakfart/SpigotCompat.java
@@ -1,0 +1,83 @@
+package nezd53.sneakfart;
+
+import org.bukkit.Particle;
+import org.bukkit.loot.LootTable;
+import org.bukkit.loot.LootTables;
+import org.bukkit.potion.PotionEffectType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Compatibility layer for handling Spigot API differences across versions.
+ * This class provides methods to abstract over API changes, ensuring compatibility with multiple Spigot versions.
+ */
+final class SpigotCompat {
+
+  static final Particle DUST_PARTICLE = getDustParticle();
+  static final LootTable EMPTY_LOOT_TABLE = getEmptyLootTable();
+  public static final PotionEffectType NAUSEA_EFFECT = getNauseaEffect();
+
+  private SpigotCompat() {
+  }
+
+  /**
+   * Retrieves the appropriate redstone particle type based on the server's Spigot API version.
+   *
+   * <p>In Spigot API 1.13 and later, {@code Particle.DUST} is used for redstone particles.
+   * In earlier versions, {@code Particle.REDSTONE} is used.</p>
+   *
+   * @return the {@link Particle} enum constant for redstone particles.
+   */
+  @NotNull
+  private static Particle getDustParticle() {
+    try {
+      return Particle.valueOf("DUST");
+    } catch (IllegalArgumentException e) {
+      return Particle.valueOf("REDSTONE");
+    }
+  }
+
+  /**
+   * Retrieves an empty loot table appropriate for the server's Spigot API version.
+   *
+   * <p>In Spigot API 1.16.2 and later, setting the loot table to {@code null} is the correct way to indicate no loot.
+   * In earlier versions, {@code LootTables.EMPTY.getLootTable()} is used to represent an empty loot table.</p>
+   *
+   * @return {@code null} for newer versions, or {@link LootTable} representing an empty loot table for older versions.
+   */
+  @Nullable
+  private static LootTable getEmptyLootTable() {
+    try {
+      LootTables empty = LootTables.valueOf("EMPTY");
+      return empty.getLootTable();
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  /**
+   * Retrieves the appropriate potion effect type for nausea based on the server's Spigot API version.
+   *
+   * <p>In Spigot API 1.13 and later, {@code PotionEffectType.NAUSEA} is used.
+   * In earlier versions, {@code PotionEffectType.CONFUSION} is used to represent the same effect.</p>
+   *
+   * @return the {@link PotionEffectType} for nausea.
+   */
+  @NotNull
+  private static PotionEffectType getNauseaEffect() {
+    PotionEffectType type = getByName("nausea");
+    if (type == null) {
+      type = getByName("confusion");
+    }
+    if (type == null) {
+      throw new IllegalArgumentException("Neither 'NAUSEA' nor 'CONFUSION' potion effect type is available.");
+    }
+    return type;
+  }
+
+  // `getByName()` is deprecated but the best option for now as PotionEffectType has changed quite a lot between 1.19 and 1.21
+  @SuppressWarnings("deprecation")
+  private static @Nullable PotionEffectType getByName(String key) {
+    return PotionEffectType.getByName(key);
+  }
+}


### PR DESCRIPTION
## Found with:

`mvn versions:display-dependency-updates -DallowSnapshots=true`

## Code changes due to spigot-api update:

- Particle.REDSTONE is now Particle.DUST
- LootTables.EMPTY was removed, `.setLootTable(null)' can be used instead
- PotionEffectType.CONFUSION was removed, PotionEffectType.NAUSEA is similar

## Compatibility solution

The changes in spigot-api break compatibility across versions. The wrapper class `SpigotCompat` solves this for now.

## Compatibility check

The script `scripts/check-spigot-compatibility.sh` can be used to check (`mvn verify`) with each available spigot-api by:
- loading spigot-api versions from maven repo
- loop over last per minor version
- run `mvn verify` with version